### PR TITLE
go fmt applied

### DIFF
--- a/vendor/github.com/smartystreets/assertions/internal/oglematchers/transform_description.go
+++ b/vendor/github.com/smartystreets/assertions/internal/oglematchers/transform_description.go
@@ -23,7 +23,7 @@ func transformDescription(m Matcher, newDesc string) Matcher {
 }
 
 type transformDescriptionMatcher struct {
-	desc string
+	desc           string
 	wrappedMatcher Matcher
 }
 


### PR DESCRIPTION
Would it be possible for you to amend http2curl to include the formatting change? It makes it more convenient for vendoring http2curl in a project that insists on applying `go fmt ./...` and seems like a good stylistic thing to do anyway :)