### PR TITLE
Import comments are obsoleted by go.mod

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,1 +1,1 @@
-package http2curl // import "moul.io/http2curl/v2"
+package http2curl // import "moul.io/http2curl"


### PR DESCRIPTION
Import comment is breaking import, specifically in gorequest. 
> Import path checking is also disabled when using modules. Import path comments are obsoleted by the go.mod file's module statement.

See https://golang.org/cmd/go/#hdr-Import_path_checking

