### PR TITLE
[fix] http2curl expects import moul.io/http2curl

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,1 +1,1 @@
-package http2curl // import "moul.io/http2curl"
+package http2curl


### PR DESCRIPTION
- referencing opened issue https://github.com/moul/http2curl/issues/27

