### PR TITLE
fix:  Test ExampleGetCurlCommand_emptyStringBody wrong output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ gin-bin
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IDE settings
+.idea

--- a/http2curl_test.go
+++ b/http2curl_test.go
@@ -74,7 +74,7 @@ func ExampleGetCurlCommand_emptyStringBody() {
 	fmt.Println(command)
 
 	// Output:
-	// curl -X 'PUT' -d '' -H 'Content-Type: application/json' 'http://www.example.com/abc/def.ghi?jlk=mno&pqr=stu'
+	// curl -X 'PUT' -H 'Content-Type: application/json' 'http://www.example.com/abc/def.ghi?jlk=mno&pqr=stu'
 }
 
 func ExampleGetCurlCommand_newlineInBody() {


### PR DESCRIPTION
bug introduced in #24