### PR TITLE
feat: avoid clobbering original body for next read

### DIFF
--- a/http2curl.go
+++ b/http2curl.go
@@ -3,6 +3,7 @@ package http2curl
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"sort"
 	"strings"
@@ -37,8 +38,10 @@ func GetCurlCommand(req *http.Request) (*CurlCommand, error) {
 		var buff bytes.Buffer
 		_, err := buff.ReadFrom(req.Body)
 		if err != nil {
-			return nil, fmt.Errorf("getCurlCommand: buffer read from body erorr: %w", err)
+			return nil, fmt.Errorf("getCurlCommand: buffer read from body error: %w", err)
 		}
+		// reset body for potential re-reads
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(buff.Bytes()))
 		if len(buff.String()) > 0 {
 			bodyEscaped := bashEscape(buff.String())
 			command.append("-d", bodyEscaped)
@@ -60,3 +63,4 @@ func GetCurlCommand(req *http.Request) (*CurlCommand, error) {
 
 	return &command, nil
 }
+


### PR DESCRIPTION
Hello! If you read the request body the way you do, subsequent layers (like a logging middleware) will find it empty. This copy's the original body and reads that, preserving the original for subsequent reads.

Signed-off-by: Steve Coffman <steve@khanacademy.org>

<!-- Thank you for your contribution! ❤️ -->
