### PR TITLE
Escape Raw Brackets In Request URLs

### DIFF
--- a/http2curl.go
+++ b/http2curl.go
@@ -26,6 +26,10 @@ func bashEscape(str string) string {
 	return `'` + strings.Replace(str, `'`, `'\''`, -1) + `'`
 }
 
+func bracketEscape(str string) string {
+	return strings.Replace(strings.Replace(str, `[`, `\[`, -1), `]`, `\]`, -1)
+}
+
 // GetCurlCommand returns a CurlCommand corresponding to an http.Request
 func GetCurlCommand(req *http.Request) (*CurlCommand, error) {
 	if req.URL == nil {
@@ -77,7 +81,7 @@ func GetCurlCommand(req *http.Request) (*CurlCommand, error) {
 		command.append("-H", bashEscape(fmt.Sprintf("%s: %s", k, strings.Join(req.Header[k], " "))))
 	}
 
-	command.append(bashEscape(requestURL))
+	command.append(bashEscape(bracketEscape(requestURL)))
 
 	command.append("--compressed")
 


### PR DESCRIPTION
Malformed HTTP requests that leverage raw brackets in the request URL are not handled correctly by the library. For example: 

```go
req1, err := http.NewRequest("GET", "https://example.com/[", nil)
	if err != nil {
		log.Fatalf("Failed to create request: %v", err)
	}
	req1.Header.Add("User-Agent", "test-agent")
	req1.Header.Add("Accept", "*/*")
	
	command1, err := http2curl.GetCurlCommand(req1)
	if err != nil {
		log.Fatalf("Failed to generate curl command: %v", err)
	}
	fmt.Printf("Test 1 - Basic request with brackets:\n%s\n\n", command1)
```

This results in the following cURL command: 


```
curl -k -X 'GET' -H 'Accept: */*' -H 'User-Agent: test-agent' 'https://example.com/[' --compressed
```

Which results in a syntax error when run:

```bash
curl: (3) bad range specification in URL position 22:
https://example.com/[
```

This PR resolves this issue by escaping brackets in the URLs of HTTP requests. 